### PR TITLE
Fix build target for BigInt support

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,27 @@
-import { defineConfig } from 'vite'
-import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+
+const ESBUILD_MODULES_TARGET = [
+  "es2020",
+  "edge88",
+  "firefox78",
+  "chrome87",
+  // vite default setting is to support safari13
+  // https://github.com/vitejs/vite/blob/134ce6817984bad0f5fb043481502531fee9b1db/packages/vite/src/node/constants.ts#L20-L26
+  // safari13 doesn't support bigint so we can up the version to 14.
+  // https://caniuse.com/bigint
+  "safari14",
+];
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [svelte()]
-})
+  plugins: [svelte()],
+  optimizeDeps: {
+    esbuildOptions: {
+      target: ESBUILD_MODULES_TARGET,
+    },
+  },
+  build: {
+    target: ESBUILD_MODULES_TARGET,
+  },
+});


### PR DESCRIPTION
By default Vite has `safari13` in its build targets:
https://github.com/vitejs/vite/blob/134ce6817984bad0f5fb043481502531fee9b1db/packages/vite/src/node/constants.ts#L20-L26

`safari13` doesn't support `BigInt`:
https://caniuse.com/bigint

`esbuild` – Vite's build library – does not (and isn't planning to) support transpilation of `BigInt` to support runtimes without `BigInt` support.
https://github.com/evanw/esbuild/issues/732#issuecomment-770519567

The solution here is to only build for browsers with `BigInt` support, meaning overriding `safari13` -> `safari14` in Vite's defaults (all others in the default targets support `BigInt` already)